### PR TITLE
feat(output-command-as-stream):  …

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,11 +9,17 @@ import (
 func InitFlags() *models.CogoCLIFlags {
 	cogoFlags := &models.CogoCLIFlags{}
 
-	flag.StringVar(&cogoFlags.Session, "session", "", "sepcify a session to interact with")
-	flag.StringVar(&cogoFlags.Session, "s", "", "sepcify a session to interact with")
+	sessionMsg := "sepcify a session to interact with"
+	flag.StringVar(&cogoFlags.Session, "session", "", sessionMsg)
+	flag.StringVar(&cogoFlags.Session, "s", "", sessionMsg)
 
-	flag.BoolVar(&cogoFlags.IsLogging, "logger", false, "shold log")
-	flag.BoolVar(&cogoFlags.IsLogging, "l", false, "shold log")
+	isLogging := "shold log"
+	flag.BoolVar(&cogoFlags.IsLogging, "logger", false, isLogging)
+	flag.BoolVar(&cogoFlags.IsLogging, "l", false, isLogging)
+
+	isStreamMsg := "should follow and return print output in stream"
+	flag.BoolVar(&cogoFlags.IsStream, "follow", false, isStreamMsg)
+	flag.BoolVar(&cogoFlags.IsStream, "f", false, isStreamMsg)
 
 	flag.Parse()
 

--- a/cmd/output_command.go
+++ b/cmd/output_command.go
@@ -23,6 +23,6 @@ func makeOutputCommand(lockService common.LockService, logger *common.Logger) mo
 			session = services.DefaultSessionKey
 		}
 
-		return client.Output(models.NewOutputRequest(session))
+		return client.Output(models.NewOutputRequest(session, cmdInfo.Flags.IsStream))
 	}
 }

--- a/ipc/internal.go
+++ b/ipc/internal.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/royiro10/cogo/common"
+	"github.com/royiro10/cogo/models"
 )
 
 const COGO_CONN_WIN32 = "localhost:3001"
@@ -17,4 +18,17 @@ type IpcClient struct {
 type IpcServer struct {
 	Listener    net.Listener
 	ReleaseFunc common.IDisposable
+}
+
+var IPCPacketVersion = 1
+
+type ipcHeaderDefinition struct {
+	Version     uint16
+	MessageSize uint64 // not incuding header
+}
+
+type IpcPacket struct {
+	Header  ipcHeaderDefinition
+	Raw     []byte
+	Message *models.BaseCogoMessage
 }

--- a/ipc/recive_msg.go
+++ b/ipc/recive_msg.go
@@ -1,33 +1,62 @@
 package ipc
 
 import (
-	"bufio"
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 
 	"github.com/royiro10/cogo/models"
 )
 
+var ErrConnectionClosed error = errors.New("connection closed")
+
 func ReciveMsg(conn net.Conn) (models.CogoMessage, error) {
-	rawMessage, err := bufio.NewReader(conn).ReadBytes('\n')
+	ipcPacket, err := reciveIpcPacket(conn)
 	if err != nil {
-		return nil, fmt.Errorf("error reading(ReadingBytes): %v", err)
+		return nil, err
 	}
 
-	var data models.BaseCogoMessage
-	if err := json.Unmarshal(rawMessage, &data); err != nil {
-		return nil, fmt.Errorf("error reading(UnmarshelBaseMsg): %v", err)
-	}
-
-	msg := models.GetMessage(*data.GetDetails())
+	msg := models.GetMessage(*ipcPacket.Message.GetDetails())
 	if msg == nil {
-		return nil, fmt.Errorf("error reading(Unrecognized msg) %v", data.GetDetails())
+		return nil, fmt.Errorf("error reading(Unrecognized msg) %v", ipcPacket.Message.GetDetails())
 	}
 
-	if err := json.Unmarshal(rawMessage, msg); err != nil {
+	if err := json.Unmarshal(ipcPacket.Raw, msg); err != nil {
 		return nil, fmt.Errorf("error reading(UnmarshelMsg::%s): %v", msg.GetDetails().Type, err)
 	}
 
 	return msg, nil
+}
+
+func reciveIpcPacket(conn net.Conn) (*IpcPacket, error) {
+	headerSize := binary.Size(ipcHeaderDefinition{})
+	headerBytes := make([]byte, headerSize)
+	if _, err := io.ReadFull(conn, headerBytes); err != nil {
+		return nil, err
+	}
+
+	packet := IpcPacket{
+		Header:  ipcHeaderDefinition{},
+		Raw:     nil,
+		Message: &models.BaseCogoMessage{},
+	}
+
+	if err := binary.Read(bytes.NewReader(headerBytes), binary.BigEndian, &packet.Header); err != nil {
+		return &packet, err
+	}
+
+	packet.Raw = make([]byte, packet.Header.MessageSize)
+	if _, err := io.ReadFull(conn, packet.Raw); err != nil {
+		return &packet, err
+	}
+
+	if err := json.Unmarshal(packet.Raw, packet.Message); err != nil {
+		return &packet, fmt.Errorf("error reading(UnmarshelBaseMsg): %v", err)
+	}
+
+	return &packet, nil
 }

--- a/models/cogo_cli_flag.go
+++ b/models/cogo_cli_flag.go
@@ -4,4 +4,6 @@ type CogoCLIFlags struct {
 	IsLogging bool
 
 	Session string
+
+	IsStream bool
 }

--- a/models/requests.go
+++ b/models/requests.go
@@ -58,11 +58,13 @@ var OutputRequestDetails = CogoMessageDetails{Version: 1, Type: MessageType(Outp
 type OutputRequest struct {
 	BaseCogoMessage
 	SessionId string
+	IsStream  bool
 }
 
-func NewOutputRequest(sessionId string) *OutputRequest {
+func NewOutputRequest(sessionId string, isStream bool) *OutputRequest {
 	return &OutputRequest{
 		BaseCogoMessage: BaseCogoMessage{OutputRequestDetails},
 		SessionId:       sessionId,
+		IsStream:        isStream,
 	}
 }

--- a/models/response.go
+++ b/models/response.go
@@ -51,12 +51,12 @@ var OutputResponseDetails = CogoMessageDetails{Version: 1, Type: MessageType(Out
 
 type OutputResponse struct {
 	BaseCogoMessage
-	Lines []StdLine
+	StdLine
 }
 
-func NewOutputResponse(output *[]StdLine) *OutputResponse {
+func NewOutputResponse(output *StdLine) *OutputResponse {
 	return &OutputResponse{
 		BaseCogoMessage: BaseCogoMessage{OutputResponseDetails},
-		Lines:           *output,
+		StdLine:         *output,
 	}
 }


### PR DESCRIPTION
solves: #11

- added stream flag for output command which follow output
- refactor and upgraded IPC package to include custom message header and send IPC packets for better parsing and debugging of communication 